### PR TITLE
Add Actions CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,39 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Upload debug APK
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        name: mset9installer-debug.apk
+        path: app/build/outputs/apk/debug/app-debug.apk
+        
+    - name: Upload unsigned release APK
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        name: mset9installer-release.apk
+        path: app/build/outputs/apk/release/app-release-unsigned.apk
+      


### PR DESCRIPTION
Pushing commits now creates APKs that can be directly downloaded from the actions artifact page.